### PR TITLE
Update META.info

### DIFF
--- a/META.info
+++ b/META.info
@@ -7,5 +7,5 @@
     "provides" : {
         "FastCGI::NativeCall" : "lib/FastCGI/NativeCall.pm6"
     },
-    "source-url" : "git://github.com/carbin/p6-fcgi.git"
+    "source-url" : "git://github.com/nbrown/p6-fcgi.git"
 }


### PR DESCRIPTION
Hi,
it appears you changed your GH username and forgot to change it in the META.info

I already changed it in the modules list so this just makes it installable again :)